### PR TITLE
Added support for widget options

### DIFF
--- a/src/AddressFinderWidget/ControlManifest.Input.xml
+++ b/src/AddressFinderWidget/ControlManifest.Input.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="Pcf" constructor="AddressFinderWidget" version="0.0.1" display-name-key="AddressFinder Widget" description-key="AddressFinder Widget" control-type="standard">
-    <!-- property node identifies a specific, configurable piece of data that the control expects from CDS -->
+  <control namespace="Pcf" constructor="AddressFinderWidget" version="1.1.10" display-name-key="AddressFinder Widget" description-key="AddressFinder Widget" control-type="standard">
     <property name="address_line_1" display-name-key="Line 1" description-key="The address line 1." of-type="SingleLine.Text" usage="bound" required="false" />
     <property name="address_line_2" display-name-key="Line 2" description-key="The address line 2." of-type="SingleLine.Text" usage="bound" required="false" />
     <property name="city" display-name-key="City" description-key="The address city." of-type="SingleLine.Text" usage="bound" required="false" />
@@ -9,36 +8,16 @@
     <property name="postcode" display-name-key="Post Code" description-key="The address post code." of-type="SingleLine.Text" usage="bound" required="false" />
     <property name="country" display-name-key="Country" description-key="The address country." of-type="SingleLine.Text" usage="bound" required="false" />
     <property name="api_key" display-name-key="API Key" description-key="Your AddressFinder API Key." of-type="SingleLine.Text" usage="input" required="true" />
-    <!-- 
-      Property node's of-type attribute can be of-type-group attribute. 
-      Example:
-      <type-group name="numbers">
-        <type>Whole.None</type>
-        <type>Currency</type>
-        <type>FP</type>
-        <type>Decimal</type>
-      </type-group>
-      <property name="sampleProperty" display-name-key="Property_Display_Key" description-key="Property_Desc_Key" of-type-group="numbers" usage="bound" required="true" />
-    -->
+    <property name="options_empty_content" display-name-key="Options: Empty Content" description-key="Message to display to users when there are no found addresses or locations." of-type="SingleLine.Text" usage="input" required="false" />
+    <property name="options_ignore_returns" display-name-key="Options: Ignore Returns" description-key="Ignore the use of the enter key when no list item is selected. (Default: true)" of-type="SingleLine.Text" usage="input" required="false" />
+    <property name="options_max_results" display-name-key="Options: Max Results" description-key="Maximum number of results to display. (Default: 10)" of-type="Whole.None" usage="input" required="false" />
+    <property name="options_show_addresses" display-name-key="Options: Show Addresses" description-key="Set to false to hide address results. (Deafualt: true)" of-type="SingleLine.Text" usage="input" required="false" />
+    <property name="options_show_locations" display-name-key="Options: Show Locations" description-key="Set to true to return locationresults. (Deafult: false)" of-type="SingleLine.Text" usage="input" required="false" />
+    <property name="options_show_nearby" display-name-key="Options: Show Nearby" description-key="Enable the nearby address helper. (Default: false)" of-type="SingleLine.Text" usage="input" required="false" />
+    <property name="options_show_points_of_interest" display-name-key="Options: Show Points of Interest" description-key="Set to true to return points of interest results. (Default: false)" of-type="SingleLine.Text" usage="input" required="false" />
     <resources>
       <code path="index.ts" order="1"/>
       <css path="css/AddressFinderWidget.css" order="1" />
-      <!-- UNCOMMENT TO ADD MORE RESOURCES
-      <css path="css/AddressFinderWidget.css" order="1" />
-      <resx path="strings/AddressFinderWidget.1033.resx" version="1.0.0" />
-      -->
     </resources>
-    <!-- UNCOMMENT TO ENABLE THE SPECIFIED API
-    <feature-usage>
-      <uses-feature name="Device.captureAudio" required="true" />
-      <uses-feature name="Device.captureImage" required="true" />
-      <uses-feature name="Device.captureVideo" required="true" />
-      <uses-feature name="Device.getBarcodeValue" required="true" />
-      <uses-feature name="Device.getCurrentPosition" required="true" />
-      <uses-feature name="Device.pickFile" required="true" />
-      <uses-feature name="Utility" required="true" />
-      <uses-feature name="WebAPI" required="true" />
-    </feature-usage>
-    -->
   </control>
 </manifest>

--- a/src/AddressFinderWidget/ControlManifest.Input.xml
+++ b/src/AddressFinderWidget/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="Pcf" constructor="AddressFinderWidget" version="1.1.10" display-name-key="AddressFinder Widget" description-key="AddressFinder Widget" control-type="standard">
+  <control namespace="Pcf" constructor="AddressFinderWidget" version="1.1.15" display-name-key="AddressFinder Widget" description-key="AddressFinder Widget" control-type="standard">
     <property name="address_line_1" display-name-key="Line 1" description-key="The address line 1." of-type="SingleLine.Text" usage="bound" required="false" />
     <property name="address_line_2" display-name-key="Line 2" description-key="The address line 2." of-type="SingleLine.Text" usage="bound" required="false" />
     <property name="city" display-name-key="City" description-key="The address city." of-type="SingleLine.Text" usage="bound" required="false" />

--- a/src/AddressFinderWidget/index.ts
+++ b/src/AddressFinderWidget/index.ts
@@ -27,7 +27,7 @@ export class AddressFinderWidget implements ComponentFramework.StandardControl<I
 	 * Constructor.
 	 */
 	constructor() {
-		this.AddressFinder = require("./widget");		
+		this.AddressFinder = require("./widget");
 	}
 
 	/**
@@ -73,7 +73,7 @@ export class AddressFinderWidget implements ComponentFramework.StandardControl<I
 			city: this._city,
 			suburb: this._suburb,
 			postcode: this._postcode,
-			country: this._country,
+			country: this._country
 		};
 	}
 
@@ -92,7 +92,8 @@ export class AddressFinderWidget implements ComponentFramework.StandardControl<I
 		this.Widget = new this.AddressFinder.Widget(
 			document.getElementById("addressfinder_search"),
 			this._context.parameters.api_key.raw,
-			"NZ"
+			"NZ",
+			this.getOptions()
 		);
 
 		this.Widget.on("result:select", (fullAddress: any, metaData: any) => {
@@ -115,5 +116,44 @@ export class AddressFinderWidget implements ComponentFramework.StandardControl<I
 		this._inputElement.setAttribute("type", "text");
 		this._inputElement.value = this._address_line_1;
 		this._container.appendChild(this._inputElement);
+	}
+
+	/** 
+	 * Build the AddressFinder options object.
+	 * @returns an object containing the AddressFinder Widget options
+	 */
+	private getOptions(): object {
+		var options: { [k: string]: any } = {};
+		options.address_params = {};
+
+		// Empty content
+		if (this._context.parameters.options_empty_content.raw != null && this._context.parameters.options_empty_content.raw != "")
+			options.empty_content = this._context.parameters.options_empty_content.raw;
+
+		// Ignore returns
+		if (this._context.parameters.options_ignore_returns.raw == "false")
+			options.ignore_returns = false;
+
+		// Max results
+		if (this._context.parameters.options_max_results.raw != null)
+			options.max_results = this._context.parameters.options_max_results.raw;
+
+		// Show addresses
+		if (this._context.parameters.options_show_addresses.raw == "false")
+			options.show_addresses = false;
+
+		// Show locations
+		if (this._context.parameters.options_show_locations.raw == "true")
+			options.show_locations = true;
+
+		// Show nearby
+		if (this._context.parameters.options_show_nearby.raw == "true")
+			options.show_nearby = true;
+
+		// Show points of interest
+		if (this._context.parameters.options_show_points_of_interest.raw == "true")
+			options.show_points_of_interest = true;
+
+		return options;
 	}
 }

--- a/src/solution/Other/Solution.xml
+++ b/src/solution/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="AddressFinder Widget" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.1.10</Version>
+    <Version>1.1.15</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/src/solution/Other/Solution.xml
+++ b/src/solution/Other/Solution.xml
@@ -5,10 +5,10 @@
     <UniqueName>AddressFinderWidget</UniqueName>
     <LocalizedNames>
       <!-- Localized Solution Name in language code -->
-      <LocalizedName description="AddressFinder Widget - https://github.com/ryanmichaeljames/pcf-addressfinder-widget" languagecode="1033" />
+      <LocalizedName description="AddressFinder Widget" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.0</Version>
+    <Version>1.1.10</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>


### PR DESCRIPTION
Added support for widget options:
- empty_content
- ignore_returns
- max_results
- show_addresses
- show_locations
- show_nearby
- show_points_of_interest

See [widget documentation](https://addressfinder.nz/docs/widget_docs)